### PR TITLE
AEA-3450 Added Service Search secret to getSecretsLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is called by an Apigee proxy that is defined at https://github.com/NHSDigital
 
 ## Functionality
 
-This repository is designed to create a Lambda layer that can be invoked during Lambda startup. Its primary purpose is to inject secret values into environment variables. Specifically, it should be used by any Lambda that utilizes the spineClient to set spine connectivity variables.
+This repository is designed to create a Lambda layer that can be invoked during Lambda startup. Its primary purpose is to inject secret values into environment variables. Specifically, it should be used by any Lambda that utilizes the spineClient or serviceSearchClient, to set connectivity variables.
 
 ### Usage
 

--- a/src/get-secrets-layer
+++ b/src/get-secrets-layer
@@ -55,12 +55,15 @@ fullPath=$(dirname $(readlink -f $0))
 # The path to the interpreter and all of the originally intended arguments
 args=("$@")
 
-# get the secrets and set to environment variable
+# get the spine secrets and set to environment variables
 get_secret ${SpinePrivateKeyARN} SpinePrivateKey
 get_secret ${SpinePublicCertificateARN} SpinePublicCertificate
 get_secret ${SpineASIDARN} SpineASID
 get_secret ${SpineCAChainARN} SpineCAChain
 get_secret ${SpinePartyKeyARN} SpinePartyKey
+
+# get the service search api key and set to an environment variable
+get_secret ${ServiceSearchApiKeyARN} ServiceSearchApiKey
 
 # Determine if AWS_LAMBDA_EXEC_WRAPPER points to this layer
 # This is necessary as the Secret may have not specified a 


### PR DESCRIPTION
## Summary

- Routine Change
- :sparkles: New Feature

### Details

Does what it says on the tin really. Enables the use of the API key for the service search capability.

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
